### PR TITLE
Long press to collapse all

### DIFF
--- a/client/src/features/feeds/FeedMobileView.tsx
+++ b/client/src/features/feeds/FeedMobileView.tsx
@@ -206,7 +206,7 @@ export default function FeedMobileView({
           [styles.NotSticky]: settings.hideStickyHeaders,
         })}
         onClick={() => {
-          if (!shouldCollapse) scrollToTopOfFeed();
+          scrollToTopOfFeed();
         }}
       >
         <div className={styles.TopRow}>


### PR DESCRIPTION
On mobile, long pressing on feed titles will collapse all feeds to make navigating between them easier. Tapping on the feed title will re-expand all feeds and scroll to the tapped feed.